### PR TITLE
Automate gh pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "start": "cp ./src/index.html ./dist/index.html && webpack serve --open verbose",
     "clean": "rm -rf ./dist/*",
     "test": "webpack --config webpack-test.config.js",
-    "prettier": "prettier --write \"./**/*.{js,scss,json,jsx,html}\""
+    "prettier": "prettier --write \"./**/*.{js,scss,json,jsx,html}\"",
+    "push-gh-pages": "./scripts/push-to-gh-pages.sh"
   },
   "author": "Brendan Gannon",
   "license": "not licensed for reproduction or use",

--- a/scripts/push-to-gh-pages.sh
+++ b/scripts/push-to-gh-pages.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-push to github pages script
-
 # builds app in /dist folder
 cp ./src/index.html ./dist/index.html && webpack
 

--- a/scripts/push-to-gh-pages.sh
+++ b/scripts/push-to-gh-pages.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+push to github pages script
+
+# builds app in /dist folder
+cp ./src/index.html ./dist/index.html && webpack
+
+# creates backup not tracked in git
+mkdir ./dist-backup && cp ./dist/* ./dist-backup/
+
+# switch to gh-pages branch
+git checkout gh-pages
+
+# replace root of gh-pages with built app from backup
+cp ./dist-backup/* ./
+
+# remove backup
+rm -r ./dist-backup
+
+# show changes to be published
+git status
+
+echo "you are now on the gh-pages branch. Commit and push to update with published changes."


### PR DESCRIPTION
Adds script that switches to `gh-pages` branch and copies the built app there. Committing and pushing the changes still deliberately manual